### PR TITLE
Update apparmor-profile

### DIFF
--- a/apparmor-profile
+++ b/apparmor-profile
@@ -50,6 +50,10 @@
   # Allow reading of libs and /tmp
   /etc/ld.so.cache r,
 
+
+  # tlsdate looks into proc for answers
+  /proc/meminfo r,
+  
   # Random number generation requires these two
   /dev/random r,
   /dev/urandom r,

--- a/apparmor-profile
+++ b/apparmor-profile
@@ -146,6 +146,7 @@
 
   # Required for gethostbyname
   /etc/resolv.conf r,
+  /run/resolvconf/resolv.conf r,
   /etc/nsswitch.conf r,
   /etc/localtime r,
   /etc/nsswitch.conf r,

--- a/apparmor-profile
+++ b/apparmor-profile
@@ -180,6 +180,9 @@
   /dev/rtc0 rw,
   /dev/rtc1 rw,
 
+  # syslog
+  /dev/log w,
+  
   # Allow mapping of shared libraries
   /lib{,32,64}/* rm,
   /usr/lib/* rm,

--- a/apparmor-profile
+++ b/apparmor-profile
@@ -198,4 +198,7 @@
   # We'll allow tlsdated to exec tlsdate-helper
   /usr/bin/tlsdate-helper ixm,
   /usr/bin/tlsdate ixm,
+  
+  # Allow unconfined processes to send signals
+  signal (receive) peer=unconfined,
 }


### PR DESCRIPTION
Ubuntu 14.04 
I'm getting warnings from apparmor about `/usr/sbin/tlsdated` daemon. 

```
apparmor="DENIED" operation="open" profile="/usr/sbin/tlsdated" name="/run/resolvconf/resolv.conf" pid=1727 comm="tlsdate-helper" requested_mask="r" denied_mask="r" fsuid=65534 ouid=0
```

I've added  `/run/resolvconf/resolv.con r`  for `/usr/sbin/tlsdated` daemon.

Allow unconfined processes to send signal. 
